### PR TITLE
[adjusters/foca] Exclude (by name) Skyguide features from FOCA dataset

### DIFF
--- a/geospatial-utils/config.py
+++ b/geospatial-utils/config.py
@@ -8,6 +8,7 @@ class ConverterConfiguration(ImplicitDict):
     name: str
     ed318_additions: ED318Additions
     adjusters: list[str]
+    excluded_features_ed318_identifiers: list[str] = []
 
 
 class ED318Additions(ImplicitDict):

--- a/geospatial-utils/configs/FOCA.json
+++ b/geospatial-utils/configs/FOCA.json
@@ -3,6 +3,10 @@
     "adjusters": [
         "foca"
     ],
+    "excluded_features_ed318_identifiers": [
+        "CTR0004",
+        "CTR0015"
+    ],
     "ed318_additions": {
         "default_lang": "en-GB",
         "provider": [

--- a/geospatial-utils/main.py
+++ b/geospatial-utils/main.py
@@ -12,6 +12,7 @@ from config import ConverterConfiguration
 from fileutils import ed269
 from implicitdict import ImplicitDict
 from loguru import logger
+from uas_standards.eurocae_ed318 import Feature
 
 version = os.environ.get("GEOSPATIAL_UTILS_VERSION", "unknown")
 
@@ -73,6 +74,26 @@ def main():
                 sys.exit(1)
 
             ed318_data = getattr(adjusters, adjuster).adjust(ed318_data)
+
+        # Filter out intentionally excluded features
+        if (
+            "excluded_features_ed318_identifiers" in config
+            and config.excluded_features_ed318_identifiers
+        ):
+
+            def _should_keep(feat: Feature) -> bool:
+                if "properties" not in feat or feat.properties is None:
+                    return True
+                return (
+                    feat.properties.identifier
+                    not in config.excluded_features_ed318_identifiers
+                )
+
+            filtered_features = list(filter(_should_keep, ed318_data.features))
+            logger.info(
+                f"Excluded {len(ed318_data.features) - len(filtered_features)} feature(s)"
+            )
+            ed318_data.features = filtered_features
 
         # Save to file
         output = pathlib.Path(args.output_file)


### PR DESCRIPTION
Fix https://github.com/focagis/geoawareness-cis/issues/12

I've opted to add a configuration option `excluded_features_ed318_identifiers` as I did not find a sensible way of parsing the Skyguide dataset. Please LMK if that's not OK and we can discuss how to do that.